### PR TITLE
Add new Solana minter addresses

### DIFF
--- a/usdc/solana/minters.json
+++ b/usdc/solana/minters.json
@@ -1,4 +1,4 @@
 {
-  "devnet": ["9JywdjbDkb8a3nqcouuLV8TDZ2UA8whwpMN5Eett6b2h", "AKy7FobAN2PqQhZpq3egmgNs4qB6RH4fkUy9o1gw8qJa"],
-  "mainnet": ["27T5c11dNMXjcRuko9CeUy3Wq41nFdH3tz9Qt4REzZMM", "28VqfqsUUBx59i8ruG2TuC5RekW5ZY3tsK4bSV59sXjn", "3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa"]
+  "devnet": ["9JywdjbDkb8a3nqcouuLV8TDZ2UA8whwpMN5Eett6b2h", "AKy7FobAN2PqQhZpq3egmgNs4qB6RH4fkUy9o1gw8qJa", "AEfKU8wHGtYgsXpymQ6e1cGHJJeKqCj95pw82iyRUKEs", "HvGvtiJxH61iqPidQLuTRZBGV1Pn4ojTn7oAanoLts4s"],
+  "mainnet": ["27T5c11dNMXjcRuko9CeUy3Wq41nFdH3tz9Qt4REzZMM", "28VqfqsUUBx59i8ruG2TuC5RekW5ZY3tsK4bSV59sXjn", "3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa", "FSxJ85FXVsXSr51SeWf9ciJWTcRnqKFSmBgRDeL3KyWw"]
 }


### PR DESCRIPTION
Adds new Solana minter addresses for CCTP functionality. 

Addresses:
[devnet cctp pre-minter 1](https://explorer.solana.com/address/HvGvtiJxH61iqPidQLuTRZBGV1Pn4ojTn7oAanoLts4s?cluster=devnet)
[devnet cctp pre-minter 2](https://explorer.solana.com/address/AEfKU8wHGtYgsXpymQ6e1cGHJJeKqCj95pw82iyRUKEs?cluster=devnet)
[mainnet cctp pre-minter](https://explorer.solana.com/address/FSxJ85FXVsXSr51SeWf9ciJWTcRnqKFSmBgRDeL3KyWw) 