### PR TITLE
[STABLE-5064] Add solana EURC devnet minters.

### DIFF
--- a/eurc/solana/minters.json
+++ b/eurc/solana/minters.json
@@ -1,0 +1,4 @@
+{
+  "devnet": ["FvtKTZ5EWdCTPAXmYUmqhZryHh2ZXSgvGhZT37TqcSep", "Fennf9fFDDoUpqEeLt3ym3oMQqi5WF83A2dxanEVSayY"],
+  "mainnet": []
+}


### PR DESCRIPTION
Just setup the solana devnet EURC minters. Add them here.

You can look them up as `SELECT * FROM stablecoins.activity_addresses aa WHERE aa.token='EURCSOL'` in both sandbox and smokebox, and they're also listed on the E2E sheet https://circlepay.atlassian.net/wiki/spaces/ENGINEERIN/pages/886505495/EURCSOL+E2E+Testing

https://circlepay.atlassian.net/browse/STABLE-5064