### PR TITLE
[STABLE-5064] Add solana EURC mainnet minters.

### DIFF
--- a/eurc/solana/minters.json
+++ b/eurc/solana/minters.json
@@ -1,4 +1,4 @@
 {
   "devnet": ["FvtKTZ5EWdCTPAXmYUmqhZryHh2ZXSgvGhZT37TqcSep", "Fennf9fFDDoUpqEeLt3ym3oMQqi5WF83A2dxanEVSayY"],
-  "mainnet": []
+  "mainnet": ["89LjSs8wP3EZNCKcs8aCxngQaEuyhUyGE4STkFwNgRT3", "HQHDva1bR4vqxvz6Y8yaLvqkD4AeWCDso8aJ9v5rfLHY"]
 }


### PR DESCRIPTION
Just setup the solana mainnet EURC minters. Add them here.

You can look them up as SELECT * FROM stablecoins.activity_addresses aa WHERE aa.token='EURCSOL' in both prod and stg, and they're also listed on the E2E sheet https://circlepay.atlassian.net/wiki/spaces/ENGINEERIN/pages/886505495/EURCSOL+E2E+Testing

https://circlepay.atlassian.net/browse/STABLE-5064