### PR TITLE
[STABLE-5157] Set EURCSOL metadata

### DIFF
--- a/eurc/solana/metadata.json
+++ b/eurc/solana/metadata.json
@@ -1,0 +1,6 @@
+{
+  "name": "EURC",
+  "symbol": "EURC",
+  "description": "EURC is a fully collateralized euro stablecoin.",
+  "image": "https://www.circle.com/hubfs/Brand/EURC/EURC-icon_128x128.png"
+}


### PR DESCRIPTION
# Summary

Added meta data for EURC on Solana. Similar to what was done in the past [here](https://www.circle.com/hubfs/stellar.toml.txt), but discussed in this [thread ](https://circlefin.slack.com/archives/C029148JX3J/p1700508052812199) migrating to hosting the data in this repository.

JSON format found [here](https://developers.metaplex.com/token-metadata/token-standard) from the fungible standard.

# Story

https://circlepay.atlassian.net/browse/STABLE-5157
