### PR TITLE
Add solana preminters

### DIFF
--- a/usdc/solana/minters.json
+++ b/usdc/solana/minters.json
@@ -1,4 +1,4 @@
 {
-  "devnet": ["9JywdjbDkb8a3nqcouuLV8TDZ2UA8whwpMN5Eett6b2h", "AKy7FobAN2PqQhZpq3egmgNs4qB6RH4fkUy9o1gw8qJa", "AEfKU8wHGtYgsXpymQ6e1cGHJJeKqCj95pw82iyRUKEs", "HvGvtiJxH61iqPidQLuTRZBGV1Pn4ojTn7oAanoLts4s"],
-  "mainnet": ["27T5c11dNMXjcRuko9CeUy3Wq41nFdH3tz9Qt4REzZMM", "28VqfqsUUBx59i8ruG2TuC5RekW5ZY3tsK4bSV59sXjn", "3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa", "FSxJ85FXVsXSr51SeWf9ciJWTcRnqKFSmBgRDeL3KyWw"]
+  "devnet": ["9JywdjbDkb8a3nqcouuLV8TDZ2UA8whwpMN5Eett6b2h", "AKy7FobAN2PqQhZpq3egmgNs4qB6RH4fkUy9o1gw8qJa", "AEfKU8wHGtYgsXpymQ6e1cGHJJeKqCj95pw82iyRUKEs", "HvGvtiJxH61iqPidQLuTRZBGV1Pn4ojTn7oAanoLts4s", "CFUgYpbas5UdJkwwSobYgzhFqFuj6C8MfXwBetE3o4SY"],
+  "mainnet": ["27T5c11dNMXjcRuko9CeUy3Wq41nFdH3tz9Qt4REzZMM", "28VqfqsUUBx59i8ruG2TuC5RekW5ZY3tsK4bSV59sXjn", "3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa", "FSxJ85FXVsXSr51SeWf9ciJWTcRnqKFSmBgRDeL3KyWw", "6xTBTqJMBr5m7BKqVxmW2x11DfqUwtD3TJsqpxELx72L"]
 }


### PR DESCRIPTION
## Summary

Adds new Solana preminters for CCTP V2.

- [Mainnet preminter](https://solscan.io/account/CCTPV2vPZJS2u2BBsUoscuikbYjnpFmbFsvVuJdgUMQe?accountName=LocalToken#accountsData:~:text=custody,%226xTBTqJMBr5m7BKqVxmW2x11DfqUwtD3TJsqpxELx72L%22)
- [Devnet preminter](https://solscan.io/account/CFUgYpbas5UdJkwwSobYgzhFqFuj6C8MfXwBetE3o4SY?cluster=devnet)
